### PR TITLE
[SGP-11427] Upgrade django-meetup to support Django 2

### DIFF
--- a/meetup/models.py
+++ b/meetup/models.py
@@ -327,7 +327,7 @@ class Event(models.Model):
 
 
     venue = models.ManyToManyField(Venue)
-    group = models.ForeignKey(Group)
+    group = models.ForeignKey(Group, on_delete=models.CASCADE)
 
     # timezone to view event times in
     _view_tz = DEFAULT_VIEW_TIMEZONE


### PR DESCRIPTION
Adds a missing `on_delete=models.CASCADE` which allows the app to be installed under Django 2.  